### PR TITLE
Move PGLT bin mapping to AsmPrinter

### DIFF
--- a/include/llvm/CodeGen/AsmPrinter.h
+++ b/include/llvm/CodeGen/AsmPrinter.h
@@ -112,6 +112,9 @@ public:
   typedef std::pair<const GlobalVariable *, unsigned> GOTEquivUsePair;
   MapVector<const MCSymbol *, GOTEquivUsePair> GlobalGOTEquivs;
 
+  /// Sections that need to be referenced in the PGLT
+  std::vector<const MCSection*> PGLT;
+
 private:
   MCSymbol *CurrentFnBegin = nullptr;
   MCSymbol *CurrentFnEnd = nullptr;
@@ -426,6 +429,14 @@ public:
   /// basic block.
   MCSymbol *GetBlockAddressSymbol(const BlockAddress *BA) const;
   MCSymbol *GetBlockAddressSymbol(const BasicBlock *BB) const;
+
+  /// Return the MCSymbol for the start of the section containing this global
+  /// object, if available.
+  MCSymbol *GetSectionSymbol(const GlobalObject *GO) const;
+
+  /// Return the index of the section containing this global object, if
+  /// available.
+  unsigned GetPGLTIndex(const GlobalObject *GO);
 
   //===------------------------------------------------------------------===//
   // Emission Helper Routines.

--- a/include/llvm/CodeGen/AsmPrinter.h
+++ b/include/llvm/CodeGen/AsmPrinter.h
@@ -112,9 +112,6 @@ public:
   typedef std::pair<const GlobalVariable *, unsigned> GOTEquivUsePair;
   MapVector<const MCSymbol *, GOTEquivUsePair> GlobalGOTEquivs;
 
-  /// Sections that need to be referenced in the PGLT
-  std::vector<const MCSection*> PGLT;
-
 private:
   MCSymbol *CurrentFnBegin = nullptr;
   MCSymbol *CurrentFnEnd = nullptr;
@@ -130,6 +127,9 @@ private:
 
   /// If VerboseAsm is set, a pointer to the loop info for this function.
   MachineLoopInfo *LI = nullptr;
+
+  /// Sections that need to be referenced in the PGLT
+  std::vector<const MCSection*> PGLT;
 
   struct HandlerInfo {
     AsmPrinterHandler *Handler;

--- a/include/llvm/CodeGen/MachineModuleInfo.h
+++ b/include/llvm/CodeGen/MachineModuleInfo.h
@@ -143,9 +143,6 @@ class MachineModuleInfo : public ImmutablePass {
   const Function *LastRequest = nullptr; ///< Used for shortcut/cache.
   MachineFunction *LastResult = nullptr; ///< Used for shortcut/cache.
 
-  typedef DenseMap<const Function *, unsigned> FuncBinMap;
-  FuncBinMap Bins;
-
 public:
   static char ID; // Pass identification, replacement for typeid
 
@@ -247,16 +244,6 @@ public:
   }
   /// \}
 
-  unsigned getBin(const Function *F) const {
-    auto I = Bins.find(F);
-    if (I != Bins.end())
-      return I->second;
-    else
-      return 0;
-  }
-  void setBin(const Function *F, unsigned Bin) {
-    Bins[F] = Bin;
-  }
 }; // End class MachineModuleInfo
 
 //===- MMI building helpers -----------------------------------------------===//

--- a/include/llvm/MC/MCContext.h
+++ b/include/llvm/MC/MCContext.h
@@ -348,21 +348,6 @@ namespace llvm {
     /// APIs.
     const SymbolTable &getSymbols() const { return Symbols; }
 
-    void setBinSymbol(unsigned BinNumber, const MCSymbol *Sym) {
-      if (BinSymbols.size() <= BinNumber-1)
-        BinSymbols.resize(BinNumber);
-
-      assert((BinSymbols[BinNumber-1] == nullptr ||
-              BinSymbols[BinNumber-1] == Sym) && "Replacing existing bin symbol");
-      BinSymbols[BinNumber-1] = Sym;
-    }
-    const MCSymbol* getBinSymbol(unsigned BinNumber) {
-      assert(BinSymbols.size() > BinNumber-1);
-      return BinSymbols[BinNumber-1];
-    }
-    ArrayRef<const MCSymbol *> getBinSymbols() {
-      return BinSymbols;
-    }
     /// @}
 
     /// \name Section Management

--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1692,8 +1692,8 @@ void AsmPrinter::EmitPGLT(const GlobalVariable *GV) {
   MCSymbol *GOTSymbol = OutContext.getOrCreateSymbol(StringRef("_GLOBAL_OFFSET_TABLE_"));
   OutStreamer->EmitValue(MCSymbolRefExpr::create(GOTSymbol, OutContext), PtrSize);
 
-  for (const MCSymbol *Sym : OutContext.getBinSymbols())
-    OutStreamer->EmitValue(MCSymbolRefExpr::create(Sym, OutContext), PtrSize);
+  for (auto *Sec : PGLT)
+    OutStreamer->EmitValue(MCSymbolRefExpr::create(Sec->getBeginSymbol(), OutContext), PtrSize);
 
   MCSymbol *PGLTEndSym = OutContext.getOrCreateSymbol(StringRef("_PGLT_END_"));
   OutStreamer->EmitSymbolAttribute(PGLTEndSym, MCSA_Global);
@@ -2540,6 +2540,22 @@ MCSymbol *AsmPrinter::GetExternalSymbolSymbol(StringRef Sym) const {
   SmallString<60> NameStr;
   Mangler::getNameWithPrefix(NameStr, Sym, getDataLayout());
   return OutContext.getOrCreateSymbol(NameStr);
+}
+
+MCSymbol *AsmPrinter::GetSectionSymbol(const GlobalObject *GO) const {
+  MCSection *Sec = getObjFileLowering().SectionForGlobal(GO, TM, MMI);
+  return Sec->getBeginSymbol();
+}
+
+unsigned AsmPrinter::GetPGLTIndex(const GlobalObject *GO) {
+  const MCSection *Sec = getObjFileLowering().SectionForGlobal(GO, TM, MMI);
+  auto I = std::find(PGLT.begin(), PGLT.end(), Sec);
+  if (I != PGLT.end()) {
+    return (I - PGLT.begin()) + 1;
+  } else {
+    PGLT.push_back(Sec);
+    return PGLT.size();
+  }
 }
 
 /// PrintParentLoopComment - Print comments about parent loops of this one.

--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2550,12 +2550,11 @@ MCSymbol *AsmPrinter::GetSectionSymbol(const GlobalObject *GO) const {
 unsigned AsmPrinter::GetPGLTIndex(const GlobalObject *GO) {
   const MCSection *Sec = getObjFileLowering().SectionForGlobal(GO, TM, MMI);
   auto I = std::find(PGLT.begin(), PGLT.end(), Sec);
-  if (I != PGLT.end()) {
-    return (I - PGLT.begin()) + 1;
-  } else {
+  auto Index = static_cast<unsigned>(I - PGLT.begin());
+  if (I == PGLT.end()) {
     PGLT.push_back(Sec);
-    return PGLT.size();
   }
+  return Index + 1;  // Index 0 denotes the default bin #0
 }
 
 /// PrintParentLoopComment - Print comments about parent loops of this one.

--- a/lib/CodeGen/PagerandoBinning.cpp
+++ b/lib/CodeGen/PagerandoBinning.cpp
@@ -20,6 +20,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/Passes.h"
@@ -47,7 +48,6 @@ public:
   }
 
 private:
-  static constexpr unsigned DefaultBin = 0;
   static constexpr unsigned BinSize = 4096; // one page
   static constexpr unsigned MinFnSize = 2;  // 'bx lr' on ARM thump
 
@@ -75,8 +75,10 @@ bool PagerandoBinning::runOnModule(Module &M) {
 
   for (auto &F : M) {
     const MachineFunction &MF = MMI.getMachineFunction(F);
-    unsigned Bin = F.isRandPage() ? AssignToBin(MF) : DefaultBin;
-    MMI.setBin(&F, Bin);
+    if (F.isRandPage()) {
+      unsigned Bin = AssignToBin(MF);
+      F.setSectionPrefix(".page" + utostr(Bin));
+    }
   }
 
   return true;

--- a/lib/CodeGen/PagerandoBinning.cpp
+++ b/lib/CodeGen/PagerandoBinning.cpp
@@ -77,6 +77,7 @@ bool PagerandoBinning::runOnModule(Module &M) {
     const MachineFunction &MF = MMI.getMachineFunction(F);
     if (F.isRandPage()) {
       unsigned Bin = AssignToBin(MF);
+      // Note: overwrites an existing section prefix
       F.setSectionPrefix(".page" + utostr(Bin));
     }
   }

--- a/lib/Target/ARM/ARMAsmPrinter.cpp
+++ b/lib/Target/ARM/ARMAsmPrinter.cpp
@@ -1058,7 +1058,7 @@ EmitMachineConstantPoolValue(MachineConstantPoolValue *MCPV) {
     auto *F = cast<Function>(cast<ARMConstantPoolConstant>(ACPV)->getGV());
 
     auto ConstantOffset = ConstantInt::get(
-        ACPV->getType(), MMI->getBin(F)*DL.getPointerSize());
+        ACPV->getType(), GetPGLTIndex(F)*DL.getPointerSize());
     return EmitGlobalConstant(DL, ConstantOffset);
   }
 
@@ -1114,10 +1114,7 @@ EmitMachineConstantPoolValue(MachineConstantPoolValue *MCPV) {
     // pagerando bin (segment).
     auto *F = cast<Function>(cast<ARMConstantPoolConstant>(ACPV)->getGV());
 
-    // Ensure that the bin for F has been created
-    getObjFileLowering().SectionForGlobal(F, TM, MMI);
-
-    const MCSymbol *BinSym = OutContext.getBinSymbol(MMI->getBin(F));
+    const MCSymbol *BinSym = GetSectionSymbol(F);
     const MCExpr *BinExpr = MCSymbolRefExpr::create(BinSym, OutContext);
     Expr = MCBinaryExpr::createSub(Expr, BinExpr, OutContext);
   }

--- a/lib/Target/ARM/ARMPGLTOptimizer.cpp
+++ b/lib/Target/ARM/ARMPGLTOptimizer.cpp
@@ -50,7 +50,7 @@ private:
   const TargetLowering *TLI;
   ARMFunctionInfo *AFI;
   const ARMSubtarget *Subtarget;
-  unsigned CurBin;
+  StringRef CurBinPrefix;
   MachineConstantPool *ConstantPool;
   bool isThumb2;
 
@@ -77,7 +77,8 @@ bool ARMPGLTOpt::runOnMachineFunction(MachineFunction &Fn) {
   TII = Subtarget->getInstrInfo();
   TLI = Subtarget->getTargetLowering();
   AFI = Fn.getInfo<ARMFunctionInfo>();
-  CurBin = MMI->getBin(Fn.getFunction());
+  // If we are in a RandPage, it should always have a section prefix
+  CurBinPrefix = Fn.getFunction()->getSectionPrefix().getValue();
   ConstantPool = Fn.getConstantPool();
   isThumb2 = Fn.getInfo<ARMFunctionInfo>()->isThumb2Function();
 
@@ -278,7 +279,7 @@ void ARMPGLTOpt::deleteOldCPEntries(SmallVectorImpl<int> &CPEntries) {
 
 bool ARMPGLTOpt::isSameBin(const GlobalValue *GV) {
   if (auto *F = dyn_cast<Function>(GV))
-    return MMI->getBin(F) == CurBin;
+    return (F->isRandPage() && F->getSectionPrefix() == CurBinPrefix);
 
   return false;
 }

--- a/lib/Target/ARM/ARMPGLTOptimizer.cpp
+++ b/lib/Target/ARM/ARMPGLTOptimizer.cpp
@@ -278,8 +278,6 @@ void ARMPGLTOpt::deleteOldCPEntries(SmallVectorImpl<int> &CPEntries) {
 }
 
 bool ARMPGLTOpt::isSameBin(const GlobalValue *GV) {
-  if (auto *F = dyn_cast<Function>(GV))
-    return (F->isRandPage() && F->getSectionPrefix() == CurBinPrefix);
-
-  return false;
+  auto F = dyn_cast<Function>(GV);
+  return F && F->isRandPage() && F->getSectionPrefix() == CurBinPrefix;
 }


### PR DESCRIPTION
Functions are now assigned to bins simply by adding a prefix to their section
name. Since sections are already uniqued by the MCContext, we know that
functions with the same section prefix will end up in the same
section/bin (assuming all other things are equal).

The AsmPrinter now lazily constructs the PGLT when PGLT entries are needed by
adding sections (bins) to an array of sections as they are referenced. When the
PGLT is emitted, the AsmPrinter emits section beginning symbols according to the
ordering in the PGLT section array.

We only ever need to resolve a PGLT offset or bin offset during the AsmPrinting
phase, so it makes sense to keep the bin referencing API exclusively in
AsmPrinter.

Change-Id: Iac2f88b8a1db61de0aef3771d52943896e5afecd