### PR TITLE
Remove TextRand section kind

### DIFF
--- a/include/llvm/MC/SectionKind.h
+++ b/include/llvm/MC/SectionKind.h
@@ -31,10 +31,6 @@ class SectionKind {
            /// ExecuteOnly, Text section that is not readable.
            ExecuteOnly,
 
-           /// TextRand - Text section location in memory should be randomized
-           /// by the loader.
-           TextRand,
-
     /// ReadOnly - Data that is never written to at program runtime by the
     /// program or the dynamic linker.  Things in the top-level readonly
     /// SectionKind are not mergeable.
@@ -120,12 +116,9 @@ public:
 
   bool isMetadata() const { return K == Metadata; }
 
-  bool isText() const {
-    return K == Text || K == ExecuteOnly || K == TextRand;
-  }
+  bool isText() const { return K == Text || K == ExecuteOnly; }
 
   bool isExecuteOnly() const { return K == ExecuteOnly; }
-  bool isTextRand() const { return K == TextRand; }
 
   bool isReadOnly() const {
     return K == ReadOnly || isMergeableCString() ||
@@ -186,7 +179,6 @@ public:
   static SectionKind getMetadata() { return get(Metadata); }
   static SectionKind getText() { return get(Text); }
   static SectionKind getExecuteOnly() { return get(ExecuteOnly); }
-  static SectionKind getTextRand() { return get(TextRand); }
   static SectionKind getReadOnly() { return get(ReadOnly); }
   static SectionKind getMergeable1ByteCString() {
     return get(Mergeable1ByteCString);

--- a/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -387,6 +387,11 @@ MCSection *TargetLoweringObjectFileELF::SelectSectionForGlobal(
     Flags |= ELF::SHF_LINK_ORDER;
   }
 
+  // Pagerando is incompatible with unique sections (enforced by driver)
+  if (auto *F = dyn_cast<Function>(GO)) {
+    assert(!(F->isPagerando() && EmitUniqueSection));
+  }
+
   MCSectionELF *Section = selectELFSectionForGlobal(
       getContext(), GO, Kind, getMangler(), TM, EmitUniqueSection, Flags,
       &NextUniqueID, AssociatedSymbol);

--- a/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -387,9 +387,10 @@ MCSection *TargetLoweringObjectFileELF::SelectSectionForGlobal(
     Flags |= ELF::SHF_LINK_ORDER;
   }
 
-  // Pagerando is incompatible with unique sections (enforced by driver)
+  // Pagerando is incompatible with unique sections.
   if (auto *F = dyn_cast<Function>(GO)) {
-    assert(!(F->isPagerando() && EmitUniqueSection));
+    if (F->isPagerando())
+      EmitUniqueSection = false;
   }
 
   MCSectionELF *Section = selectELFSectionForGlobal(

--- a/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -385,8 +385,6 @@ MCSection *TargetLoweringObjectFileELF::SelectSectionForGlobal(
   if (AssociatedSymbol) {
     EmitUniqueSection = true;
     Flags |= ELF::SHF_LINK_ORDER;
-  } else if (Kind.isTextRand()) {
-    EmitUniqueSection = false;
   }
 
   MCSectionELF *Section = selectELFSectionForGlobal(

--- a/lib/Target/TargetLoweringObjectFile.cpp
+++ b/lib/Target/TargetLoweringObjectFile.cpp
@@ -140,11 +140,8 @@ SectionKind TargetLoweringObjectFile::getKindForGlobal(const GlobalObject *GO,
   Reloc::Model ReloModel = TM.getRelocationModel();
 
   // Early exit - functions should be always in text sections.
-  if (auto *F = dyn_cast<Function>(GO)) {
-    if (F->isPagerando())
-      return SectionKind::getTextRand();
+  if (auto *F = dyn_cast<Function>(GO))
     return SectionKind::getText();
-  }
 
   const auto *GVar = cast<GlobalVariable>(GO);
 


### PR DESCRIPTION
Also adds `assert` that checks that we enforce that unique sections are not mixed with Pagerando.

Depends on immunant/android_clang#1