### PR TITLE
A few cleanups for AsmPrinter

### DIFF
--- a/include/llvm/CodeGen/AsmPrinter.h
+++ b/include/llvm/CodeGen/AsmPrinter.h
@@ -441,8 +441,6 @@ public:
   unsigned GetPOTIndex(const GlobalObject *GO);
   /// Return the POT index of the section containing this constant pool ID.
   unsigned GetPOTIndex(unsigned CPID);
-  /// Return the POT index of the section.
-  unsigned GetPOTIndex(const MCSection *Sec);
 
   //===------------------------------------------------------------------===//
   // Emission Helper Routines.
@@ -634,8 +632,9 @@ private:
                           bool isCtor);
   GCMetadataPrinter *GetOrCreateGCPrinter(GCStrategy &C);
   /// Emit GlobalAlias or GlobalIFunc.
-  void emitGlobalIndirectSymbol(Module &M,
-                                const GlobalIndirectSymbol& GIS);
+  void emitGlobalIndirectSymbol(Module &M, const GlobalIndirectSymbol &GIS);
+  /// Return the POT index of the section.
+  unsigned GetPOTIndex(const MCSection *Sec);
 };
 
 } // end namespace llvm

--- a/include/llvm/CodeGen/AsmPrinter.h
+++ b/include/llvm/CodeGen/AsmPrinter.h
@@ -437,13 +437,12 @@ public:
   MCSymbol *GetSectionSymbol(const GlobalObject *GO) const;
   MCSymbol *GetSectionSymbol(unsigned CPID) const;
 
-  /// Return the index of the section containing this global object, if
-  /// available.
+  /// Return the POT index of the section containing this global object.
   unsigned GetPOTIndex(const GlobalObject *GO);
-
-  /// Return the index of the section containing this constant pool ID, if
-  /// available
+  /// Return the POT index of the section containing this constant pool ID.
   unsigned GetPOTIndex(unsigned CPID);
+  /// Return the POT index of the section.
+  unsigned GetPOTIndex(const MCSection *Sec);
 
   //===------------------------------------------------------------------===//
   // Emission Helper Routines.

--- a/include/llvm/CodeGen/AsmPrinter.h
+++ b/include/llvm/CodeGen/AsmPrinter.h
@@ -626,8 +626,8 @@ private:
 
   void EmitJumpTableEntry(const MachineJumpTableInfo *MJTI,
                           const MachineBasicBlock *MBB, unsigned uid) const;
+  void EmitPOT();
   void EmitLLVMUsedList(const ConstantArray *InitList);
-  void EmitPOT(const GlobalVariable *GV);
   /// Emit llvm.ident metadata in an '.ident' directive.
   void EmitModuleIdents(Module &M);
   void EmitXXStructorList(const DataLayout &DL, const Constant *List,

--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1679,25 +1679,24 @@ void AsmPrinter::EmitPOT() {
   OutStreamer->SwitchSection(Section);
 
   // Emit POT start label
-  MCSymbol *POTSym = OutContext.getOrCreateSymbol(StringRef("_POT_"));
+  MCSymbol *POTSym = OutContext.getOrCreateSymbol("_POT_");
   OutStreamer->EmitSymbolAttribute(POTSym, MCSA_Global);
   OutStreamer->EmitSymbolAttribute(POTSym, MAI->getProtectedVisibilityAttr());
   OutStreamer->EmitValueToAlignment(Alignment);
   OutStreamer->EmitLabel(POTSym);
 
   // Entry 0 is GOT reference
-  auto *GOTSym = OutContext.getOrCreateSymbol(StringRef("_GLOBAL_OFFSET_TABLE_"));
-  auto *GOTRef = MCSymbolRefExpr::create(GOTSym, OutContext);
-  OutStreamer->EmitValue(GOTRef, PtrSize);
+  auto *GOTSym = OutContext.getOrCreateSymbol("_GLOBAL_OFFSET_TABLE_");
+  OutStreamer->EmitValue(MCSymbolRefExpr::create(GOTSym, OutContext), PtrSize);
 
   // Emit Bin references
   for (auto *Bin : POT) {
-    auto *BinRef = MCSymbolRefExpr::create(Bin->getBeginSymbol(), OutContext);
-    OutStreamer->EmitValue(BinRef, PtrSize);
+    auto *BinSym = Bin->getBeginSymbol();
+    OutStreamer->EmitValue(MCSymbolRefExpr::create(BinSym, OutContext), PtrSize);
   }
 
   // Emit POT end label
-  auto *POTEndSym = OutContext.getOrCreateSymbol(StringRef("_POT_END_"));
+  auto *POTEndSym = OutContext.getOrCreateSymbol("_POT_END_");
   OutStreamer->EmitSymbolAttribute(POTEndSym, MCSA_Global);
   OutStreamer->EmitSymbolAttribute(POTEndSym, MAI->getProtectedVisibilityAttr());
   OutStreamer->EmitLabel(POTEndSym);

--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1247,6 +1247,10 @@ bool AsmPrinter::doFinalization(Module &M) {
   // Emit remaining GOT equivalent globals.
   emitGlobalGOTEquivs();
 
+  // Emit POT (page offset table) if Pagerando is enabled
+  if (TM.isPagerando())
+    EmitPOT();
+
   // Emit visibility info for declarations
   for (const Function &F : M) {
     if (!F.isDeclarationForLinker())
@@ -1643,11 +1647,6 @@ bool AsmPrinter::EmitSpecialLLVMGlobal(const GlobalVariable *GV) {
   if (GV->getSection() == "llvm.metadata" ||
       GV->hasAvailableExternallyLinkage())
     return true;
-
-  if (GV->getName() == "llvm.pot") {
-    EmitPOT();
-    return true;
-  }
 
   if (!GV->hasAppendingLinkage()) return false;
 

--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1679,8 +1679,6 @@ void AsmPrinter::EmitPOT() {
 
   // Emit POT start label
   MCSymbol *POTSym = OutContext.getOrCreateSymbol("_POT_");
-  OutStreamer->EmitSymbolAttribute(POTSym, MCSA_Global);
-  OutStreamer->EmitSymbolAttribute(POTSym, MAI->getProtectedVisibilityAttr());
   OutStreamer->EmitValueToAlignment(Alignment);
   OutStreamer->EmitLabel(POTSym);
 
@@ -1696,8 +1694,6 @@ void AsmPrinter::EmitPOT() {
 
   // Emit POT end label
   auto *POTEndSym = OutContext.getOrCreateSymbol("_POT_END_");
-  OutStreamer->EmitSymbolAttribute(POTEndSym, MCSA_Global);
-  OutStreamer->EmitSymbolAttribute(POTEndSym, MAI->getProtectedVisibilityAttr());
   OutStreamer->EmitLabel(POTEndSym);
 
   OutStreamer->AddBlankLine();

--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1684,12 +1684,11 @@ void AsmPrinter::EmitPOT() {
 
   // Entry 0 is GOT reference
   auto *GOTSym = OutContext.getOrCreateSymbol("_GLOBAL_OFFSET_TABLE_");
-  OutStreamer->EmitValue(MCSymbolRefExpr::create(GOTSym, OutContext), PtrSize);
+  EmitLabelReference(GOTSym, PtrSize);
 
   // Emit Bin references
   for (auto *Bin : POT) {
-    auto *BinSym = Bin->getBeginSymbol();
-    OutStreamer->EmitValue(MCSymbolRefExpr::create(BinSym, OutContext), PtrSize);
+    EmitLabelReference(Bin->getBeginSymbol(), PtrSize);
   }
 
   // Emit POT end label

--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1678,7 +1678,7 @@ void AsmPrinter::EmitPOT() {
   OutStreamer->SwitchSection(Section);
 
   // Emit POT start label
-  MCSymbol *POTSym = OutContext.getOrCreateSymbol("_POT_");
+  auto *POTSym = OutContext.getOrCreateSymbol("_PAGE_OFFSET_TABLE_");
   OutStreamer->EmitValueToAlignment(Alignment);
   OutStreamer->EmitLabel(POTSym);
 
@@ -1692,7 +1692,7 @@ void AsmPrinter::EmitPOT() {
   }
 
   // Emit POT end label
-  auto *POTEndSym = OutContext.getOrCreateSymbol("_POT_END_");
+  auto *POTEndSym = OutContext.getOrCreateSymbol("_PAGE_OFFSET_TABLE_END_");
   OutStreamer->EmitLabel(POTEndSym);
 
   OutStreamer->AddBlankLine();

--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1247,7 +1247,7 @@ bool AsmPrinter::doFinalization(Module &M) {
   // Emit remaining GOT equivalent globals.
   emitGlobalGOTEquivs();
 
-  // Emit POT (page offset table) if Pagerando is enabled
+  // Emit POT (page offset table) if Pagerando is enabled.
   if (TM.isPagerando())
     EmitPOT();
 

--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2563,18 +2563,15 @@ MCSymbol *AsmPrinter::GetSectionSymbol(unsigned CPID) const {
 
 unsigned AsmPrinter::GetPOTIndex(const GlobalObject *GO) {
   const MCSection *Sec = getObjFileLowering().SectionForGlobal(GO, TM, MMI);
-  auto I = std::find(POT.begin(), POT.end(), Sec);
-  auto Index = static_cast<unsigned>(I - POT.begin());
-  if (I == POT.end()) {
-    POT.push_back(Sec);
-  }
-  return Index + 1;  // Index 0 denotes the default bin #0
+  return GetPOTIndex(Sec);
 }
 
-// TODO(sjc): Refactor out common code
 unsigned AsmPrinter::GetPOTIndex(unsigned CPID) {
   const MCSection *Sec = getSectionForCPI(CPID);
+  return GetPOTIndex(Sec);
+}
 
+unsigned AsmPrinter::GetPOTIndex(const MCSection *Sec) {
   auto I = std::find(POT.begin(), POT.end(), Sec);
   auto Index = static_cast<unsigned>(I - POT.begin());
   if (I == POT.end()) {

--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1644,8 +1644,10 @@ bool AsmPrinter::EmitSpecialLLVMGlobal(const GlobalVariable *GV) {
       GV->hasAvailableExternallyLinkage())
     return true;
 
-  if (GV->getName() == "llvm.pot")
+  if (GV->getName() == "llvm.pot") {
     EmitPOT(GV);
+    return true;
+  }
 
   if (!GV->hasAppendingLinkage()) return false;
 

--- a/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -4130,11 +4130,10 @@ SDValue AArch64TargetLowering::LowerPOT(SDValue Op, SelectionDAG &DAG) const {
   if (MF.getFunction()->isPagerando()) {
     return DAG.getCopyFromReg(DAG.getEntryNode(), dl, POTReg, PtrVT);
   } else {
-    SDValue Hi =
-      DAG.getTargetExternalSymbol("_POT_", PtrVT, AArch64II::MO_PAGE);
-    SDValue Lo =
-      DAG.getTargetExternalSymbol("_POT_", PtrVT,
-                                  AArch64II::MO_PAGEOFF | AArch64II::MO_NC);
+    SDValue Hi = DAG.getTargetExternalSymbol(
+        "_PAGE_OFFSET_TABLE_", PtrVT, AArch64II::MO_PAGE);
+    SDValue Lo = DAG.getTargetExternalSymbol(
+        "_PAGE_OFFSET_TABLE_", PtrVT, AArch64II::MO_PAGEOFF | AArch64II::MO_NC);
     SDValue ADRP = DAG.getNode(AArch64ISD::ADRP, dl, PtrVT, Hi);
     SDValue POTAddress = DAG.getNode(AArch64ISD::ADDlow, dl, PtrVT, ADRP, Lo);
     SDValue Chain = DAG.getCopyToReg(DAG.getEntryNode(), dl, POTReg, POTAddress);

--- a/lib/Target/AArch64/AArch64MCInstLower.cpp
+++ b/lib/Target/AArch64/AArch64MCInstLower.cpp
@@ -160,8 +160,7 @@ MCOperand AArch64MCInstLower::lowerSymbolOperandELF(const MachineOperand &MO,
       index = Printer.GetPOTIndex(MO.getIndex());
     }
     return MCOperand::createImm(index);
-  }
-  if (SourceFlag == AArch64II::MO_SEC) {
+  } else if (SourceFlag == AArch64II::MO_SEC) {
     const MCSymbol *SecSym;
     if (MO.isGlobal()) {
       auto *GO = cast<GlobalObject>(MO.getGlobal());

--- a/lib/Target/AArch64/AArch64MCInstLower.cpp
+++ b/lib/Target/AArch64/AArch64MCInstLower.cpp
@@ -160,7 +160,8 @@ MCOperand AArch64MCInstLower::lowerSymbolOperandELF(const MachineOperand &MO,
       index = Printer.GetPOTIndex(MO.getIndex());
     }
     return MCOperand::createImm(index);
-  } else if (SourceFlag == AArch64II::MO_SEC) {
+  }
+  if (SourceFlag == AArch64II::MO_SEC) {
     const MCSymbol *SecSym;
     if (MO.isGlobal()) {
       auto *GO = cast<GlobalObject>(MO.getGlobal());

--- a/lib/Target/ARM/ARMISelLowering.cpp
+++ b/lib/Target/ARM/ARMISelLowering.cpp
@@ -3016,7 +3016,7 @@ ARMTargetLowering::LowerPOT(SDValue Op, SelectionDAG &DAG) const {
     SDLoc dl(Op);
     unsigned PCAdj = Subtarget->isThumb() ? 4 : 8;
     ARMConstantPoolValue *CPV = ARMConstantPoolSymbol::Create(
-        *DAG.getContext(), "_POT_", ARMPCLabelIndex, PCAdj);
+        *DAG.getContext(), "_PAGE_OFFSET_TABLE_", ARMPCLabelIndex, PCAdj);
     SDValue CPAddr = DAG.getTargetConstantPool(CPV, PtrVT, 4);
     CPAddr = DAG.getNode(ARMISD::Wrapper, dl, MVT::i32, CPAddr);
     SDValue Result = DAG.getLoad(

--- a/lib/Transforms/IPO/PagerandoWrappers.cpp
+++ b/lib/Transforms/IPO/PagerandoWrappers.cpp
@@ -322,15 +322,4 @@ void PagerandoWrappers::createPOT(Module &M) {
   POT->setVisibility(GlobalValue::ProtectedVisibility);
 
   llvm::appendToUsed(M, {POT});
-
-  LLVMContext &C = M.getContext();
-  // TODO(yln): this can be removed, maybe, alternatively remove some redundant code in AsmPrinter::EmitPOT
-  // Set the POT base address
-  auto POTAddress = M.getGlobalVariable("_POT_");
-  if (!POTAddress) {
-    POTAddress = new GlobalVariable(M, Type::getInt8Ty(C), true,
-                                     GlobalValue::ExternalLinkage,
-                                     nullptr, "_POT_");
-    POTAddress->setVisibility(GlobalValue::ProtectedVisibility);
-  }
 }

--- a/lib/Transforms/IPO/PagerandoWrappers.cpp
+++ b/lib/Transforms/IPO/PagerandoWrappers.cpp
@@ -60,7 +60,6 @@ private:
   Function *rewriteVarargs(Function &F, Type *&VAListTy);
   Function *createWrapper(Function &F, const std::vector<Use *> &AddressUses);
   void createWrapperBody(Function *Wrapper, Function *Callee, Type *VAListTy);
-  void createPOT(Module &M);
 };
 } // end anonymous namespace
 
@@ -94,7 +93,6 @@ bool PagerandoWrappers::runOnModule(Module &M) {
   for (auto F : Worklist) {
     processFunction(F);
   }
-  createPOT(M);
 
   return true;
 }
@@ -311,15 +309,4 @@ Function *PagerandoWrappers::rewriteVarargs(Function &F, Type *&VAListTy) {
   F.eraseFromParent();
 
   return NF;
-}
-
-void PagerandoWrappers::createPOT(Module &M) {
-  auto PtrTy = Type::getInt8PtrTy(M.getContext());
-  auto Ty = ArrayType::get(PtrTy, /* NumElements */ 1);
-  auto Init = ConstantAggregateZero::get(Ty);
-  auto POT = new GlobalVariable(
-      M, Ty, /* constant */ true, GlobalValue::ExternalLinkage, Init, "llvm.pot");
-  POT->setVisibility(GlobalValue::ProtectedVisibility);
-
-  llvm::appendToUsed(M, {POT});
 }

--- a/lib/Transforms/IPO/PagerandoWrappers.cpp
+++ b/lib/Transforms/IPO/PagerandoWrappers.cpp
@@ -86,15 +86,11 @@ bool PagerandoWrappers::runOnModule(Module &M) {
     if (!skipFunction(F)) Worklist.push_back(&F);
   }
 
-  if (Worklist.empty()) {
-    return false;
-  }
-
   for (auto F : Worklist) {
     processFunction(F);
   }
 
-  return true;
+  return !Worklist.empty();
 }
 
 static bool skipFunctionUse(const Use &U);


### PR DESCRIPTION
* Extract common code from `AsmPrinter::GetPOTIndex` overloads
* Don't emit placeholder `llvm.pot` global variable, instead do `if (TM.isPagerando()) EmitPOT();`
